### PR TITLE
Show build number and author

### DIFF
--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -70,7 +70,7 @@
     (prn "Prev  - Status: " (:status build))
     (when build
       {:status 200
-       :headers {"Content-Type" "text/html"}
+       :headers {"Content-Type" "text/html; charset=utf-8"}
        :body (generate-html build previous-build refresh)})))
 
 (defn -main [& [vso-account vso-project vso-personal-access-token port]]

--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -19,9 +19,14 @@
 (defn determine-status-text [build]
   (if (in-progress? build) (:status build) (:result build)))
 
+(defn determine-build-author [build]
+  (:displayName (:requestedFor build)))
+
 (defn determine-text [build]
   (str
     (:buildNumber build)
+    " – "
+    (determine-build-author build)
     " – "
     (determine-status-text build)))
 

--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -40,7 +40,7 @@
          "<link rel=\"shortcut icon\" href=\"/favicon_" background-colour ".ico\" />"
          "</head>"
          "<body style=\"background-color:" background-colour ";\">"
-         "<h1 style=\"color:" font-colour ";font-size:400%;\">" text "</h1>"
+         "<h1 style=\"color:" font-colour ";font-size:400%;text-align:center;\">" text "</h1>"
          "</body>")))
 
 (defn handler [account project token request]

--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -16,8 +16,11 @@
         (and (in-progress? build) (not (succeeded? previous-build))) "orange"
         :default "red"))
 
-(defn determine-text [build]
+(defn determine-status-text [build]
   (if (in-progress? build) (:status build) (:result build)))
+
+(defn determine-text [build]
+  (determine-status-text build))
 
 (defn tryparse [string]
   (try (. Integer parseInt string)

--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -20,7 +20,10 @@
   (if (in-progress? build) (:status build) (:result build)))
 
 (defn determine-text [build]
-  (determine-status-text build))
+  (str
+    (:buildNumber build)
+    " – "
+    (determine-status-text build)))
 
 (defn tryparse [string]
   (try (. Integer parseInt string)

--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -1,6 +1,7 @@
 (ns build-mon.core
   (:require [ring.adapter.jetty :as ring-jetty]
             [ring.middleware.resource :as resource]
+            [ring.middleware.params :as params]
             [clj-http.client :as client]
             [cheshire.core :as json])
   (:gen-class))
@@ -18,13 +19,24 @@
 (defn determine-text [build]
   (if (in-progress? build) (:status build) (:result build)))
 
-(defn generate-html [build previous-build]
+(defn tryparse [string]
+  (try (. Integer parseInt string)
+       (catch Exception e nil)))
+
+(defn determine-refresh-rate [params]
+  (let [refresh (get params "refresh")]
+    (case refresh
+      (nil "true" "yes") 20
+      ("false" "no") nil
+      (tryparse refresh))))
+
+(defn generate-html [build previous-build refresh]
   (let [background-colour (determine-background-colour build previous-build)
         font-colour (if (in-progress? build) "black" "white")
         text (determine-text build)]
     (str "<head>"
          "<title>Build Status</title>"
-         "<meta http-equiv=\"refresh\" content=\"20\" />"
+         (if refresh (str "<meta http-equiv=\"refresh\" content=\"" refresh "\" />"))
          "<link rel=\"shortcut icon\" href=\"/favicon_" background-colour ".ico\" />"
          "</head>"
          "<body style=\"background-color:" background-colour ";\">"
@@ -36,7 +48,8 @@
                                  project "/_apis/build/builds?api-version=2.0&$top=2")
         api-response (client/get last-two-builds-url {:basic-auth ["USERNAME CAN BE ANY VALUE" token]})
         [build previous-build] (try (-> api-response :body (json/parse-string true) :value)
-                                    (catch Exception e))]
+                                    (catch Exception e))
+        refresh (determine-refresh-rate (:query-params request))]
     (prn "Build - Result: " (:result build))
     (prn "Build - Status: " (:status build))
     (prn "Prev  - Result: " (:result build))
@@ -44,12 +57,13 @@
     (when build
       {:status 200
        :headers {"Content-Type" "text/html"}
-       :body (generate-html build previous-build)})))
+       :body (generate-html build previous-build refresh)})))
 
 (defn -main [& [vso-account vso-project vso-personal-access-token port]]
   (let [port (Integer. (or port 3000))]
     (if (and vso-account vso-project vso-personal-access-token port)
       (let [wrapped-handler (-> (partial handler vso-account vso-project vso-personal-access-token)
-                                (resource/wrap-resource "public"))]
+                                (resource/wrap-resource "public")
+                                (params/wrap-params))]
         (ring-jetty/run-jetty wrapped-handler {:port port}))
       (prn "App didn't start due to missing parameters."))))

--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -25,12 +25,13 @@
     "N/A"))
 
 (defn determine-text [build]
-  (str
-    (:buildNumber build)
-    " – "
-    (determine-build-author build)
-    " – "
-    (determine-status-text build)))
+  (let [sep " – "]
+    (str
+      (:buildNumber build)
+      sep
+      (determine-build-author build)
+      sep
+      (determine-status-text build))))
 
 (defn tryparse [string]
   (try (. Integer parseInt string)

--- a/src/build_mon/core.clj
+++ b/src/build_mon/core.clj
@@ -20,7 +20,9 @@
   (if (in-progress? build) (:status build) (:result build)))
 
 (defn determine-build-author [build]
-  (:displayName (:requestedFor build)))
+  (or
+    (-> build :requestedFor :displayName)
+    "N/A"))
 
 (defn determine-text [build]
   (str

--- a/test/build_mon/test/core.clj
+++ b/test/build_mon/test/core.clj
@@ -17,6 +17,9 @@
   (is (= (c/determine-status-text failed-build) "failed"))
   (is (= (c/determine-status-text in-progress-build) "inProgress")))
 
+(deftest determine-text
+  (is (= (c/determine-text {:buildNumber "123" :result "succeeded"}) "123 – succeeded")))
+
 (deftest determine-refresh-rate
   (let [default-rate 20]
     (is (= (c/determine-refresh-rate {}) default-rate))

--- a/test/build_mon/test/core.clj
+++ b/test/build_mon/test/core.clj
@@ -12,10 +12,10 @@
   (is (= (c/determine-background-colour in-progress-build succeeded-build) "yellow"))
   (is (= (c/determine-background-colour in-progress-build failed-build) "orange")))
 
-(deftest determine-text
-  (is (= (c/determine-text succeeded-build) "succeeded"))
-  (is (= (c/determine-text failed-build) "failed"))
-  (is (= (c/determine-text in-progress-build) "inProgress")))
+(deftest determine-status-text
+  (is (= (c/determine-status-text succeeded-build) "succeeded"))
+  (is (= (c/determine-status-text failed-build) "failed"))
+  (is (= (c/determine-status-text in-progress-build) "inProgress")))
 
 (deftest determine-refresh-rate
   (let [default-rate 20]

--- a/test/build_mon/test/core.clj
+++ b/test/build_mon/test/core.clj
@@ -16,3 +16,13 @@
   (is (= (c/determine-text succeeded-build) "succeeded"))
   (is (= (c/determine-text failed-build) "failed"))
   (is (= (c/determine-text in-progress-build) "inProgress")))
+
+(deftest determine-refresh-rate
+  (let [default-rate 20]
+    (is (= (c/determine-refresh-rate {}) default-rate))
+    (is (= (c/determine-refresh-rate {"refresh" "true"}) default-rate))
+    (is (= (c/determine-refresh-rate {"refresh" "yes"}) default-rate))
+    (is (= (c/determine-refresh-rate {"refresh" "false"}) nil))
+    (is (= (c/determine-refresh-rate {"refresh" "no"}) nil))
+    (is (= (c/determine-refresh-rate {"refresh" "30"}) 30))
+    (is (= (c/determine-refresh-rate {"refresh" "rubbish"}) nil))))

--- a/test/build_mon/test/core.clj
+++ b/test/build_mon/test/core.clj
@@ -18,7 +18,8 @@
   (is (= (c/determine-status-text in-progress-build) "inProgress")))
 
 (deftest determine-build-author
-  (is (= (c/determine-build-author {:requestedFor {:displayName "Bob"}}) "Bob")))
+  (is (= (c/determine-build-author {:requestedFor {:displayName "Bob"}}) "Bob"))
+  (is (= (c/determine-build-author {}) "N/A")))
 
 (deftest determine-text
   (let [build {:buildNumber "123"

--- a/test/build_mon/test/core.clj
+++ b/test/build_mon/test/core.clj
@@ -17,8 +17,14 @@
   (is (= (c/determine-status-text failed-build) "failed"))
   (is (= (c/determine-status-text in-progress-build) "inProgress")))
 
+(deftest determine-build-author
+  (is (= (c/determine-build-author {:requestedFor {:displayName "Bob"}}) "Bob")))
+
 (deftest determine-text
-  (is (= (c/determine-text {:buildNumber "123" :result "succeeded"}) "123 – succeeded")))
+  (let [build {:buildNumber "123"
+               :result "succeeded"
+               :requestedFor {:displayName "Bob"}}]
+  (is (= (c/determine-text build) "123 – Bob – succeeded"))))
 
 (deftest determine-refresh-rate
   (let [default-rate 20]


### PR DESCRIPTION
A couple of changes (useful, I hope):
- Build number and author displayed with the build status
- Text is centred in the page
- Page is served as UTF-8 (otherwise the n-dash character, used to separate build number, author and status, is not recognised by the browser)
- Refresh interval can be changed or disabled with a query param (I used this to prevent refreshing when playing around with the markup in the browser inspector)

I hope my clojure is not too dreadful! 
